### PR TITLE
Feature/add custom get post body

### DIFF
--- a/lib/tiny_client/curb_requestor.rb
+++ b/lib/tiny_client/curb_requestor.rb
@@ -17,6 +17,17 @@ module TinyClient
                                      verbose: verbose)
       end
 
+      # Perform a get request with Curl
+      # @param [String] url the full url
+      # @param [Hash] headers  the request headers
+      # @param [Integer] connect_timeout timeout if the request connection go over (in second)
+      # @param [Boolean] verbose set curl verbose mode
+      # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)
+      # @return [TinyClient::Response] the request response
+      def perform_body_get(url, headers, content, connect_timeout, verbose)
+        perform(:GET, url, nil, content, headers: headers, connect_timeout: connect_timeout, verbose: verbose)
+      end
+
       # Perform a put request with Curl
       # @param [String] url the full url
       # @param [Hash] headers  the request headers

--- a/lib/tiny_client/curb_requestor.rb
+++ b/lib/tiny_client/curb_requestor.rb
@@ -20,11 +20,12 @@ module TinyClient
       # Perform a get request with Curl
       # @param [String] url the full url
       # @param [Hash] headers  the request headers
+      # @param [String] content the request body content
       # @param [Integer] connect_timeout timeout if the request connection go over (in second)
       # @param [Boolean] verbose set curl verbose mode
       # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)
       # @return [TinyClient::Response] the request response
-      def perform_body_get(url, headers, content, connect_timeout, verbose)
+      def perform_body_data_get(url, headers, content, connect_timeout, verbose)
         perform(:GET, url, nil, content, headers: headers, connect_timeout: connect_timeout, verbose: verbose)
       end
 

--- a/lib/tiny_client/remote_client.rb
+++ b/lib/tiny_client/remote_client.rb
@@ -16,6 +16,18 @@ module TinyClient
       }.merge!(@config.headers), @config.connect_timeout, @config.verbose)
     end
 
+    #    GET /<path>/<id>/<name>?<params>
+    # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)
+    # @return [Response]
+    def body_get(path, params, id, name, data)
+      url = @config.url_for(path, id, name, params)
+      verify_json(data)
+      CurbRequestor.perform_body_get(url, {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json'
+      }.merge!(@config.headers), data.to_json, @config.connect_timeout, @config.verbose)
+    end
+
     #    POST /<path>/<id>/<name>
     # @param [Hash] data
     # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)

--- a/lib/tiny_client/remote_client.rb
+++ b/lib/tiny_client/remote_client.rb
@@ -17,9 +17,10 @@ module TinyClient
     end
 
     #    GET /<path>/<id>/<name>?<params>
+    # @param [Hash] data
     # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)
     # @return [Response]
-    def body_get(path, params, id, name, data)
+    def body_data_get(path, params, id, name, data)
       url = @config.url_for(path, id, name, params)
       verify_json(data)
       CurbRequestor.perform_body_get(url, {

--- a/lib/tiny_client/remote_client.rb
+++ b/lib/tiny_client/remote_client.rb
@@ -23,7 +23,7 @@ module TinyClient
     def body_data_get(path, params, id, name, data)
       url = @config.url_for(path, id, name, params)
       verify_json(data)
-      CurbRequestor.perform_body_get(url, {
+      CurbRequestor.perform_body_data_get(url, {
         'Accept' => 'application/json',
         'Content-Type' => 'application/json'
       }.merge!(@config.headers), data.to_json, @config.connect_timeout, @config.verbose)

--- a/lib/tiny_client/resource.rb
+++ b/lib/tiny_client/resource.rb
@@ -65,8 +65,9 @@ module TinyClient
 
       # GET /<path>/{id}/<name>
       # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)
-      def body_get(params = {}, data, id = nil, name = nil, resource_class = nil)
-        resp = @conf.requestor.body_get(@path, params, id, name, data)
+      # @raise [ArgumentError] if data cannot be serialized as a json string ( .to_json )
+      def body_data_get(params = {}, data, id = nil, name = nil, resource_class = nil)
+        resp = @conf.requestor.body_data_get(@path, params, id, name, data)
         (resource_class || self).from_response resp
       end
 

--- a/lib/tiny_client/resource.rb
+++ b/lib/tiny_client/resource.rb
@@ -63,6 +63,13 @@ module TinyClient
         (resource_class || self).from_response resp
       end
 
+      # GET /<path>/{id}/<name>
+      # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)
+      def body_get(params = {}, data, id = nil, name = nil, resource_class = nil)
+        resp = @conf.requestor.body_get(@path, params, id, name, data)
+        (resource_class || self).from_response resp
+      end
+
       # POST /<path>/{id}/<name>
       # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)
       # @raise [ArgumentError] if data cannot be serialized as a json string ( .to_json )

--- a/lib/tiny_client/resource.rb
+++ b/lib/tiny_client/resource.rb
@@ -66,7 +66,7 @@ module TinyClient
       # GET /<path>/{id}/<name>
       # @raise [ResponseError] if the server respond with an error status (i.e 404, 500..)
       # @raise [ArgumentError] if data cannot be serialized as a json string ( .to_json )
-      def body_data_get(params = {}, data, id = nil, name = nil, resource_class = nil)
+      def body_data_get(data, params = {}, id = nil, name = nil, resource_class = nil)
         resp = @conf.requestor.body_data_get(@path, params, id, name, data)
         (resource_class || self).from_response resp
       end


### PR DESCRIPTION
### Background
https://tinyhr.atlassian.net/browse/CQ-5136
It raises `TinyClient::ResponseError`.

### Root cause
The URI too long when attach thousand of receiver ids in URL request to Engage(`/api/1.0/organizations/11/employees.json`).
```
> GET /api/1.0/organizations/11/employees.json?autocomplete=&fields%5B%5D=email&fields%5B%5D=first_name&fields%5B%5D=last_name&fields%5B%5D=avatar_url&fields%5B%5D=exit_date&ids%5B%5D=828372&ids%5B%5D=957177&ids%5B%5D=270421&ids%5B%5D=1023339&ids%5B%5D=1021605&ids%5B%5D=1002183&ids%5B%5D=1027813&ids%5B%5D=270879&ids%5B%5D=934944&ids%5B%5D=1084500&ids%5B%5D=330410&ids%5B%5D=877338&ids%5B%5D=1078558&ids%5B%5D=1021252&ids%5B%5D=1021255&ids%5B%5D=1021256&ids%5B%5D=1021262&ids%5B%5D=959826&ids%5B%5D=603484&ids%5B%5D=276839&ids%5B%5D=270715&ids%5B%5D=844936&ids%5B%5D=769702&ids%5B%5D=769709&ids%5B%5D=563924&ids%5B%5D=1024741&ids%5B%5D=712952&ids%5B%5D=1056420&ids%5B%5D=1024354&ids%5B%5D=1021264&ids%5B%5D=354114&ids%5B%5D=1021259&ids%5B%5D=822111&ids%5B%5D=628846&ids%5B%5D=270710&ids%5B%5D=1021582&ids%5B%5D=1016979&ids%5B%5D=769717&ids%5B%5D=981304&ids%5B%5D=506702&ids%5B%5D=893809&ids%5B%5D=270723&ids%5B%5D=354186&ids%5B%5D=1021581&ids%5B%5D=593625&ids%5B%5D=867509&ids%5B%5D=270342&ids%5B%5D=1021253&ids%5B%5D=270440&ids%5B%5D=908931&ids%5B%5D=908955&ids%5B%5D=577209&ids%5B%5D=1049045&ids%5B%5D=1008628&ids%5B%5D=959829&ids%5B%5D=1006900&ids%5B%5D=1015609&ids%5B%5D=712901&ids%5B%5D=1045806&ids%5B%5D=1079797&ids%5B%5D=1084696&ids%5B%5D=968137&ids%5B%5D=1047603&ids%5B%5D=1023669&ids%5B%5D=883666&ids%5B%5D=1073138&ids%5B%5D=1006902&ids%5B%5D=1014979&ids%5B%5D=270564&ids%5B%5D=1008630&ids%5B%5D=1040621&ids%5B%5D=270608&ids%5B%5D=811968&ids%5B%5D=1021273&ids%5B%5D=1005229&ids%5B%5D=1021297&ids%5B%5D=1023337&ids%5B%5D=1017480&ids%5B%5D=1075473&ids%5B%5D=1021275&ids%5B%5D=1035181&ids%5B%5D=828375&ids%5B%5D=1008631&ids%5B%5D=963866&ids%5B%5D=10
```
<img width="370" alt="Screen Shot 2020-05-12 at 8 41 24 AM" src="https://user-images.githubusercontent.com/1629726/81631552-4bd8da80-9432-11ea-8a28-bf2a630b2c97.png">

### Change
Add new a method `body_data_get `. Put large data into the request's body(for `GET`) instead of url.
