### PR TITLE
[MAINTENANCE] Bump curb dependency to support v1.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ jobs:
       gemfile: gemfiles/activesupport_5.2.gemfile
     - rvm: 2.7.7
       gemfile: gemfiles/activesupport_6.gemfile
+    - rvm: 3.0.5
+      gemfile: gemfiles/activesupport_6.gemfile
     - if: tag IS present
       stage: Release Gem
       rvm: 2.5.9

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gem install tp_client
 
 ```ruby
 # As gem main class is different from gem name, we must require file name explicitly
-gem 'tp_client', '~> 0.2.7', require: 'tiny_client'
+gem 'tp_client', '~> 0.3.0', require: 'tiny_client'
 ```
 
 Please notice, we have 2 similar gems:

--- a/tp_client.gemspec
+++ b/tp_client.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name     = 'tp_client'
-  s.version  = '0.2.7'
+  s.version  = '0.3.0'
   s.authors  = ['TINYpulse DevOps']
   s.email    = 'devops@tinypulse.com'
 
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ['--main', 'README.md']
   s.extra_rdoc_files = ['LICENSE', 'README.md']
 
-  s.add_runtime_dependency 'curb',          '> 0.7.0', '< 1.0.0'
+  s.add_runtime_dependency 'curb',          '>= 0.9.11', '< 1.1'
   s.add_runtime_dependency 'activesupport', '>= 4.0',  '< 7.0'
 
   s.add_development_dependency 'appraisal', '~> 2.2', '>= 2.2.0'


### PR DESCRIPTION
### SUMMARY

- Bump curb dependency to support v1.0+

### CHANGES

- Bump curb dependency to support v1.0.0+
- Update README
- Test with Ruby 3.0.5
